### PR TITLE
add a new_no_alloc to LruCache for cases when memory is precious

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,14 @@ impl<K, V> LruCache<K, V> {
         }
     }
 
+    pub fn new_no_alloc(capacity: usize) -> LruCache<K, V> {
+        Self {
+            cache: Default::default(),
+            counter: AtomicU64::default(),
+            capacity,
+        }
+    }
+
     /// An iterator visiting all key-value pairs in arbitrary order.
     /// The iterator element type is `(&'a K, &'a V)`.
     pub fn iter(&self) -> Iter<'_, K, V> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ extern crate alloc;
 pub struct LruCache<K, V> {
     cache: HashMap<K, (/*ordinal:*/ AtomicU64, V)>,
     counter: AtomicU64,
-    capacity: usize,
+    pub capacity: usize,
 }
 
 /// An iterator over the entries of an `LruCache`.


### PR DESCRIPTION
I have a case where I create a lot of caches that may or may not be filled, I don't want to pre-allocate for each and every one of them. Would love it if this could be merged. Thanks!